### PR TITLE
updates to menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -291,6 +291,12 @@ a:hover,a:focus,a:visited {
 		left:10px;
 	}
 }
+@media screen and (min-width:1100px){
+	#navbar-title,#navbar-title-headline{
+		width:79%;
+		left:1em;
+	}
+}
 #navbar-title-headline .glyphicon{
 	top:2px;
 	left:2px;

--- a/css/style.css
+++ b/css/style.css
@@ -410,25 +410,53 @@ Hero
 #hero{
   background: url('img/hero_bg.jpg') center center no-repeat;
   background-size: cover;
-  height:300px;
+  height:420px;
   width:100%;
   text-align: center;
   margin: 50px 0 0;
+}
+#hero .container-fluid{
+	height:420px;
+	max-width: 960px;
 }
 #hero-joco-logo{
 	width:75%;
 	max-width: 390px;
 	height: auto;
-	position: relative;
-	top: 100px;
+	margin: 100px 0;
+}
+.hero-button{
+	width:220px;
+	height:auto;
+	background:none;	
+	margin: 1em auto;
+	padding:.5em;
+	border:1px solid #f6f4ec;
+	border-radius: 2px;
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px;
+	transition: background .27s;
+	-moz-transition: background .27s;
+	-webkit-transition: background .27s;
+}
+.hero-button a{
+	width:100%;
+	color:#FFF;
+	text-transform: uppercase;
+	font-family: gothamBook;
+	font-size: 12px;
+}
+.hero-button:hover{
+	background:rgba(255,255,255,.25);
 }
 @media screen and (min-width:768px){
-	#hero{
-		height:400px;
-	}
 	#hero-joco-logo{
 		width:100%;
 		top: 144px;
+	}
+	.hero-button{
+		display: inline-block;
+		margin: 0 25px;
 	}
 }
 #hero-about{

--- a/css/style.css
+++ b/css/style.css
@@ -2652,7 +2652,7 @@ SPONSORS
 	text-align: center;
 }
 #sponsors .container-fluid{
-	padding:36px 0 0;
+	padding:36px 0;
 	max-width:750px;
 	margin: 0 auto;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -210,7 +210,6 @@ a:hover,a:focus,a:visited {
 	-moz-border-radius:none;
 	-webkit-border-radius:none;
 	background:#022D46;
-	color:#FFF;
 	position: relative;
 	top:1px;
 	left:0;
@@ -218,6 +217,7 @@ a:hover,a:focus,a:visited {
 @media screen and (min-width:768px){
 	#nav-button-inner{
 		margin: 0 15px 0 0;
+		padding: 18px 60px 18px 15px;
 	}
 	.navbar-toggle{
 		display: block;	
@@ -242,9 +242,28 @@ a:hover,a:focus,a:visited {
 	width:10%;
 	min-width:50px;
 	height:100%;
+	position: relative;
 }
+@media screen and (min-width:768px){
+	#nav-button{
+		width:6em;
+	}
+	#nav-button:hover,#nav-button:active{
+		background-color:#022D46;
+	}
+}
+.nav-button-title{
+	text-transform: uppercase;
+	font-family: gothamBook, sans-serif;
+	font-size: 10px;
+	position: absolute;
+	top: 0;
+	right: 1.5em;
+	line-height: 52px;
+	color:#6e96ab;
+ }
 #navbar-title,#navbar-title-headline{
-	width:80%;
+	width:75%;
 	height:100%;
 	text-align:center;
 }
@@ -265,6 +284,7 @@ a:hover,a:focus,a:visited {
 @media screen and (min-width:768px){
 	#navbar-title-headline{
 		font-size: 16px;
+		left:.5em;
 	}
 	#navbar-title{
 		position: relative;
@@ -301,7 +321,7 @@ a:hover,a:focus,a:visited {
 }
 @media screen and (min-width:768px){
 	#navbar-title img{
-	left: 0;
+	left: -.5em;
 	}
 	#nav-arrow-to-top{
 		width:10%;

--- a/css/style.css
+++ b/css/style.css
@@ -337,11 +337,28 @@ a:hover,a:focus,a:visited {
 	padding: 0 0 5px;
 	border-bottom: 2px solid #022D46;
 }
+.navbar-default .navbar-nav>li.child{
+	padding:0 0 0 3em;
+}
+.navbar-nav>li.child>a{
+	padding:7px 0;	
+}
+.navbar-nav>li.child>a:first-of-type{
+	padding: 0 0 7px 0;
+}
+.navbar-nav>li.child>a:list-of-type{
+	padding: 7px 0 0 0;
+}
+.navbar-default .navbar-nav>li.child>a span{
+	color:#cdc5a5;
+}
 .navbar-default .navbar-nav>li>a span:hover{
 	color:#6e96ab;
 	cursor: pointer;
 	border-bottom: 2px solid #6e96ab;
 }
+
+
 @media screen and (min-width:768px){
 .navbar-collapse.collapse {
 display: none !important;

--- a/css/style.css
+++ b/css/style.css
@@ -2680,7 +2680,7 @@ SPONSORS
 	text-align: center;
 }
 #sponsors .container-fluid{
-	padding:36px 0;
+	padding:36px 0 0;
 	max-width:750px;
 	margin: 0 auto;
 }

--- a/functions.php
+++ b/functions.php
@@ -30,12 +30,17 @@ function mac_clean_menu() {
 		$menu_items = wp_get_nav_menu_items($menu->term_id);
 		$menu_list='';
 		foreach ((array) $menu_items as $key => $menu_item) {
+			$has_parent = $menu_item->menu_item_parent;
+			$child = '';
+			if ($has_parent > 0){
+				$child = ' class="child"';
+			}
 			$title = $menu_item->title;
 			$url = $menu_item->url;
 			if (is_front_page()){
-				$menu_list .= "\t\t\t\t\t". '<li><a href="'. $url .'"><span>'. $title .'</span></a></li>' ."\n";
+				$menu_list .= "\t\t\t\t\t". '<li'.$child.'><a href="'. $url .'"><span>'. $title .'</span></a></li>' ."\n";
 			} else {
-				$menu_list .= "\t\t\t\t\t". '<li><a href="/'. $url .'"><span>'. $title .'</span></a></li>' ."\n";
+				$menu_list .= "\t\t\t\t\t". '<li'.$child.'><a href="/'. $url .'"><span>'. $title .'</span></a></li>' ."\n";
 			}
 		}
 	} else {

--- a/header.php
+++ b/header.php
@@ -20,6 +20,7 @@
 			        <span class="icon-bar"></span>
 			        <span class="icon-bar"></span>
 			        <span class="icon-bar"></span>
+        				<p class="nav-button-title hidden-xs">Menu</p>
 				</button>
 			</div>
 			<?php 

--- a/header.php
+++ b/header.php
@@ -39,7 +39,7 @@
 					<img src="<?php bloginfo('template_directory'); ?>/img/hero_JoCo_LoGo.png" alt="A styled JoCo Cruise logotype." id="nav-joco-logo">
 				</a>
 	  <?php } else { ?>
-				<a id="navbar-title" href="#wrapper" class="navbar-item-left">
+				<a id="navbar-title" href="/" class="navbar-item-left">
 					<img src="<?php bloginfo('template_directory'); ?>/img/hero_JoCo_LoGo.png" alt="A styled JoCo Cruise logotype." id="nav-joco-logo">
 				</a>
 	  <?php } ?>

--- a/index.php
+++ b/index.php
@@ -9,6 +9,14 @@ get_header();
 		<div class="container-fluid">
 			<div class="col-xs-12 col-md-12">
 				<img src="<?php bloginfo('template_directory'); ?>/img/hero_JoCo_LoGo.png" alt="A styled JoCo Cruise logotype." id="hero-joco-logo">
+				<?php if (isset($hero_book_now)){ ?>
+					<div class="hero-buttons">
+						<div class="hero-button"><a href="<?php echo $booking_url; ?>"><?php echo $hero_book_now; ?></a></div>
+					<?php };?>
+					<?php if (isset($booked)){ ?>
+						<div class="hero-button"><a href="<?php echo $booked_url; ?>"><?php echo $booked; ?></a></div>
+					</div>
+				<?php };?>
 			</div>
 		</div>
 	</section>

--- a/index.php
+++ b/index.php
@@ -205,6 +205,12 @@ wp_reset_postdata();
 								}
 								wp_reset_postdata();
 							?>
+						
+							<?php if ($artists_more == 1) { ?>
+							<div class="artist_unit artists-artist headers featured-guests" id="item-2">
+								<h1><span>Plus</span><br>More to Come Soon!</h1>
+							</div>
+							<?php }; ?>
 						</div>
 					</div>
 				</div>

--- a/js/js_behavior.js
+++ b/js/js_behavior.js
@@ -229,7 +229,7 @@ jQuery(document).ready(function(jQuery) {
 	
 	//menu swap behavior
 	if ($('#navbar-title-headline').length){
-		var offset = jQuery('#about').offset();
+		var offset = jQuery('#news').offset();
 		if (jQuery(document).scrollTop() > offset.top) {
 			jQuery('#navbar-title-headline').hide(function(){
 				jQuery('#navbar-title').fadeIn('slow',function(){

--- a/mac_options.php
+++ b/mac_options.php
@@ -170,6 +170,14 @@ function mac_settings_init(  ) {
 		'mac_artist_settings' 
 	);
 	
+	add_settings_field( 
+		'mac_enable_more', 
+		__( 'Enable More To Come', 'wordpress' ), 
+		'mac_enable_more_render', 
+		'pluginPage', 
+		'mac_artist_settings' 
+	);
+	
 	//contact settings
 	add_settings_section(
 		'mac_contact_settings', 
@@ -413,6 +421,14 @@ function mac_talent_header_render(  ) {
 	$options = get_option( 'mac_settings' );
 	?>
 	<textarea cols='80' rows='3' name='mac_settings[mac_talent_header]'><?php echo $options['mac_talent_header']; ?></textarea>
+	<?php 
+}
+
+function mac_enable_more_render(  ) { 
+
+	$options = get_option( 'mac_settings' );
+	?>
+	<input type='checkbox' name='mac_settings[mac_enable_more]' <?php checked( $options['mac_enable_more'], 1 ); ?> value='1'>
 	<?php 
 }
 

--- a/mac_options.php
+++ b/mac_options.php
@@ -96,6 +96,30 @@ function mac_settings_init(  ) {
 		'mac_hero_settings' 
 	);
 	
+	add_settings_field( 
+		'mac_hero_book_now', 
+		__( 'Hero Book Now Button', 'wordpress' ), 
+		'mac_hero_book_now_render', 
+		'pluginPage', 
+		'mac_hero_settings'
+	);
+	
+	add_settings_field( 
+		'mac_hero_already_booked', 
+		__( 'Hero Already Booked Button', 'wordpress' ), 
+		'mac_hero_already_booked_render', 
+		'pluginPage', 
+		'mac_hero_settings'
+	);
+	
+	add_settings_field( 
+		'mac_hero_already_booked_url', 
+		__( 'Hero Already Booked URL', 'wordpress' ), 
+		'mac_hero_already_booked_url_render', 
+		'pluginPage', 
+		'mac_hero_settings'
+	);
+	
 	//mailing list
 	add_settings_field( 
 		'mac_mailing_list_cta', 
@@ -308,6 +332,30 @@ function mac_button_cta_render(  ) {
 	<?php 
 }
 
+function mac_hero_already_booked_render(  ) { 
+
+	$options = get_option( 'mac_settings' );
+	?>
+	<input type="text" size="80" name='mac_settings[mac_hero_already_booked_render]' value='<?php echo $options['mac_hero_already_booked_render']; ?>'>
+	<?php 
+}
+
+function mac_hero_already_booked_url_render(  ) { 
+
+	$options = get_option( 'mac_settings' );
+	?>
+	<input type="text" size="80" name='mac_settings[mac_hero_already_booked_url]' value='<?php echo $options['mac_hero_already_booked_url']; ?>'>
+	<?php 
+}
+
+
+function mac_hero_book_now_render(  ) { 
+
+	$options = get_option( 'mac_settings' );
+	?>
+	<input type="text" size="80" name='mac_settings[mac_hero_book_now]' value='<?php echo $options['mac_hero_book_now']; ?>'>
+	<?php 
+}
 function mac_travel_description_render(  ) { 
 
 	$options = get_option( 'mac_settings' );

--- a/mac_options.php
+++ b/mac_options.php
@@ -336,7 +336,7 @@ function mac_hero_already_booked_render(  ) {
 
 	$options = get_option( 'mac_settings' );
 	?>
-	<input type="text" size="80" name='mac_settings[mac_hero_already_booked_render]' value='<?php echo $options['mac_hero_already_booked_render']; ?>'>
+	<input type="text" size="80" name='mac_settings[mac_hero_already_booked]' value='<?php echo $options['mac_hero_already_booked']; ?>'>
 	<?php 
 }
 

--- a/theme_variables.php
+++ b/theme_variables.php
@@ -20,6 +20,7 @@ $travel_desc_more = $settings['mac_travel_description_more'];
 $mailing_cta = $settings['mac_mailing_list_cta'];
 //artists
 $artists_header = $settings['mac_talent_header'];
+$artists_more = $settings['mac_enable_more'];
 //contact
 $cont_gen_q = $settings['mac_general_questions_header'];
 $cont_gen_q_addy = $settings['mac_general_questions_address_header'];

--- a/theme_variables.php
+++ b/theme_variables.php
@@ -1,27 +1,38 @@
 <?php
 
 $settings = get_option('mac_settings');
+
 //variables
 $site_title = get_bloginfo('name');
+//booking
 $booking_url = $settings['mac_booking_url'];
+$hero_book_now = $settings['mac_hero_book_now'];
+$booked = $settings['mac_hero_already_booked'];
+$booked_url = $settings['mac_hero_already_booked_url'];
 $booking_enabled = $settings['mac_booking_enabled'];
 $booking_cta = $settings['mac_button_cta'];
+//cruise info
 $cruise_fb = $settings['mac_facebook_url'];
 $cruise_twitter = $settings['mac_twitter_url'];
 $cruise_rss = $settings['mac_feed_url'];
 $travel_desc = $settings['mac_travel_description'];
 $travel_desc_more = $settings['mac_travel_description_more'];
 $mailing_cta = $settings['mac_mailing_list_cta'];
+//artists
 $artists_header = $settings['mac_talent_header'];
+//contact
 $cont_gen_q = $settings['mac_general_questions_header'];
 $cont_gen_q_addy = $settings['mac_general_questions_address_header'];
 $cont_book_q = $settings['mac_booking_questions_header'];
 $cont_book_q_addy = $settings['mac_booking_questions_address_header'];
 $cont_tel = $settings['mac_phone_questions_header'];
 $cont_tel_addy = $settings['mac_phone_questions_address_header'];
+//map
 $map_copy = $settings['mac_map_copy'];
+//news
 $news_header = $settings['mac_news_header'];
 $news_view_all = $settings['mac_news_view_all'];
 $news_view_url = $settings['mac_news_view_all_url'];
+//footer
 $footer_text = $settings['mac_footer_text'];
 ?>


### PR DESCRIPTION
Looks to solve issue #31

I didn't change the icon to a disclosure triangle because there's no room for the word _menu_ in the narrow layout. So, it doesn't make sense to just have an arrow sitting there. Additionally, the word menu does not appear on the narrow layout because there's no where to put it but since that's mainly for phones/tablets and that's usually a native app button, hopefully it will have enough context. Please let me know if you'd like to find another solution. (For example, don't show the headline in the narrow layout.)

Because the menu must be so custom, we don't have wp support for flagging parents. The only issue this causes is that the menu is not _semantic_ semantic. It's just semantic but not quite in the way it's intended if that makes sense.
